### PR TITLE
Setup to use Yii's clientscript meta tag system

### DIFF
--- a/yiiseo/components/SeoExt.php
+++ b/yiiseo/components/SeoExt.php
@@ -173,7 +173,7 @@ class SeoExt extends CApplicationComponent
         if($name == "title")
             echo "<title>$content</title>\n";
         else{
-            echo "<meta name='$name' content='$content' />\n";
+            Yii::app()->clientScript->registerMetaTag($content, $name);
         }
     }
 


### PR DESCRIPTION
Ok, trying this again.  Thought it could be helpful to have this use Yii's CClientScript `registerMetaTag` function as other behaviors may adjust it before it's output.
